### PR TITLE
Add status getters for gift card creation and cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@
 *.so
 *.o
 *.a
+.idea/*
 mkmf.log

--- a/lib/aws_agcod/cancel_gift_card.rb
+++ b/lib/aws_agcod/cancel_gift_card.rb
@@ -4,7 +4,7 @@ module AGCOD
   class CancelGiftCard
     extend Forwardable
 
-    def_delegators :@response, :success?, :error_message
+    def_delegators :@response, :status, :success?, :error_message
 
     def initialize(request_id, gc_id)
       @response = Request.new("CancelGiftCard",

--- a/lib/aws_agcod/create_gift_card.rb
+++ b/lib/aws_agcod/create_gift_card.rb
@@ -8,7 +8,7 @@ module AGCOD
 
     CURRENCIES = %w(USD EUR JPY CNY CAD)
 
-    def_delegators :@response, :success?, :error_message
+    def_delegators :@response, :status, :success?, :error_message
 
     def initialize(request_id, amount, currency = "USD")
       unless CURRENCIES.include?(currency.to_s)

--- a/spec/aws_agcod/cancel_gift_card_spec.rb
+++ b/spec/aws_agcod/cancel_gift_card_spec.rb
@@ -3,6 +3,7 @@ require "aws_agcod/cancel_gift_card"
 
 describe AGCOD::CancelGiftCard do
   let(:partner_id) { "Testa" }
+  let(:response) { spy }
 
   before do
     AGCOD.configure do |config|
@@ -19,9 +20,29 @@ describe AGCOD::CancelGiftCard do
         expect(action).to eq("CancelGiftCard")
         expect(params["creationRequestId"]).to eq(request_id)
         expect(params["gcId"]).to eq(gc_id)
-      end.and_return(spy)
+      end.and_return(response)
 
       AGCOD::CancelGiftCard.new(request_id, gc_id)
+    end
+  end
+
+  shared_context "request with response" do
+    let(:gc_id) { "BAR" }
+    let(:creation_request_id) { "BAZ" }
+    let(:status) { "SUCCESS" }
+    let(:request) { AGCOD::CancelGiftCard.new(creation_request_id, gc_id) }
+
+    before do
+      allow(AGCOD::Request).to receive(:new) { double(response: response) }
+      allow(response).to receive(:status) { status }
+    end
+  end
+
+  context "#status" do
+    include_context "request with response"
+
+    it "returns the response status" do
+      expect(request.status).to eq(status)
     end
   end
 end

--- a/spec/aws_agcod/create_gift_card_spec.rb
+++ b/spec/aws_agcod/create_gift_card_spec.rb
@@ -49,12 +49,14 @@ describe AGCOD::CreateGiftCard do
     let(:expiration_date) { "Wed Mar 12 22:59:59 UTC 2025" }
     let(:gc_id) { "BAR" }
     let(:creation_request_id) { "BAZ" }
+    let(:status) { "SUCCESS" }
     let(:payload) { {"gcClaimCode" => claim_code, "gcId" => gc_id, "creationRequestId" => creation_request_id, "gcExpirationDate" => expiration_date} }
     let(:request) { AGCOD::CreateGiftCard.new(request_id, amount, currency) }
 
     before do
       allow(AGCOD::Request).to receive(:new) { double(response: response) }
       allow(response).to receive(:payload) { payload }
+      allow(response).to receive(:status) { status }
     end
   end
 
@@ -87,6 +89,14 @@ describe AGCOD::CreateGiftCard do
 
     it "returns creation request_id" do
       expect(request.request_id).to eq(creation_request_id)
+    end
+  end
+
+  context "#status" do
+    include_context "request with response"
+
+    it "returns the response status" do
+      expect(request.status).to eq(status)
     end
   end
 end


### PR DESCRIPTION
Add getters to `CreateGiftCard` and `CancelGiftCard` for the AGCOD API response status.

This allows clients to distinguish between the "FAILURE" and "RESEND" statuses, as well as to log or otherwise process the original status code returned by the AGCOD API.
