### PR TITLE
Allow usage of Amazon-supplied mock request IDs

### DIFF
--- a/lib/aws_agcod/request.rb
+++ b/lib/aws_agcod/request.rb
@@ -6,6 +6,7 @@ require "yaml"
 module AGCOD
   class Request
     TIME_FORMAT = "%Y%m%dT%H%M%SZ"
+    MOCK_REQUEST_IDS = %w(F0000 F2005)
 
     attr_reader :response
 
@@ -44,8 +45,8 @@ module AGCOD
     end
 
     def sanitized_params(params)
-      # Prefix partner_id when it's not given as part of request_id for creationRequestId
-      if params["creationRequestId"] && !(params["creationRequestId"] =~ /#{AGCOD.config.partner_id}/)
+      # Prefix partner_id when it's not given as part of request_id for creationRequestId and it's not a mock request_id
+      if params["creationRequestId"] && !(params["creationRequestId"] =~ /#{AGCOD.config.partner_id}/) && !(MOCK_REQUEST_IDS.member?(params["creationRequestId"]))
         params["creationRequestId"] = "#{AGCOD.config.partner_id}#{params["creationRequestId"]}"
       end
 


### PR DESCRIPTION
In Amazon's tech documentation they supply the two request IDs in this commit to force a success or failure response, but given that the partner ID is always prefixed this PR is necessary to only prefix it when the mock IDs are not present.