### PR TITLE
Other endpoints and re-configuring 

### DIFF
--- a/lib/aws_agcod.rb
+++ b/lib/aws_agcod.rb
@@ -6,7 +6,7 @@ require "aws_agcod/gift_card_activity_list"
 
 module AGCOD
   def self.configure(&block)
-    @config = Config.new
+    @config ||= Config.new
 
     yield @config
 

--- a/lib/aws_agcod/config.rb
+++ b/lib/aws_agcod/config.rb
@@ -9,8 +9,16 @@ module AGCOD
                   :production
 
     URI = {
-      sandbox: "https://agcod-v2-gamma.amazon.com",
-      production: "https://agcod-v2.amazon.com"
+      sandbox: {
+        "us-east-1" => "https://agcod-v2-gamma.amazon.com",
+        "eu-west-1" => "https://agcod-v2-eu-gamma.amazon.com",
+        "us-west-2" => "https://agcod-v2-fe-gamma.amazon.com"
+      },
+      production: {
+        "us-east-1" => "https://agcod-v2.amazon.com",
+        "eu-west-1" => "https://agcod-v2-eu.amazon.com",
+        "us-west-2" => "https://agcod-v2-fe.amazon.com"
+      }
     }
 
     def initialize
@@ -22,8 +30,7 @@ module AGCOD
 
     def uri
       return @uri if @uri
-
-      production ? URI[:production] : URI[:sandbox]
+      production ? URI[:production][@region] : URI[:sandbox][@region]
     end
   end
 end

--- a/spec/aws_agcod/config_spec.rb
+++ b/spec/aws_agcod/config_spec.rb
@@ -25,19 +25,43 @@ describe AGCOD::Config do
     end
 
     context "when uri is not set" do
-      context "when production is enabled" do
-        before do
-          config.production = true
+      context "with default region" do
+        context "when production is enabled" do
+          before do
+            config.production = true
+          end
+
+          it "returns the us-east-1 production uri" do
+            expect(config.uri).to eq(AGCOD::Config::URI[:production]["us-east-1"])
+          end
         end
 
-        it "returns the production uri" do
-          expect(config.uri).to eq(AGCOD::Config::URI[:production])
+        context "when production is disabled" do
+          it "returns the us-east-1 sandbox uri" do
+            expect(config.uri).to eq(AGCOD::Config::URI[:sandbox]["us-east-1"])
+          end
         end
       end
 
-      context "when production is disabled" do
-        it "returns the sandbox uri" do
-          expect(config.uri).to eq(AGCOD::Config::URI[:sandbox])
+      context "with specified region" do
+        before do
+          config.region = "eu-west-1"
+        end
+
+        context "when production is enabled" do
+          before do
+            config.production = true
+          end
+
+          it "returns the specified production uri" do
+            expect(config.uri).to eq(AGCOD::Config::URI[:production]["eu-west-1"])
+          end
+        end
+
+        context "when production is disabled" do
+          it "returns the us-east-1 sandbox uri" do
+            expect(config.uri).to eq(AGCOD::Config::URI[:sandbox]["eu-west-1"])
+          end
         end
       end
     end


### PR DESCRIPTION
Hi again!

I've a need to be able to buy cards in multiple currencies and regions in the same app so I've added a couple of changes to make this easier. Again, I don't know if you're interested in these changes but  here they are if you do :)

Firstly, the API has different endpoints for different regions which only service certain currencies. I've altered `AGCOD.config.uri` to return the correct URI given the currently set region and whether it's in production mode. This can, of course, still be overriden with a custom URI

Secondly, I've changed the way the `AGCOD.configure` config works slightly.  Previously it would always create a new `AGCOD::Config` object, initialised with the defaults, which meant in order to change one value (like the region for instance) you'd have to re-set everything again including secret keys and so on. I've changed it so that it will use an existing configuration for attributes you don't change.

It's worth mentioning that there's a tiny edge case where this could break an existing app if it was relying on `AGCOD.configure` to change the `production`, `region` or `timeout` values back to their defaults from a previously set value. It would be a bit of a weird way to do it but I thought it worth mentioning!

While I'm here, thanks for this gem by the way, which saved  me from doing a lot of irritating work :smile: 